### PR TITLE
Adding cjson as prerequisite for OPM Flow

### DIFF
--- a/docs/_sources/installation.rst.txt
+++ b/docs/_sources/installation.rst.txt
@@ -134,7 +134,7 @@ If you would like to build the latest OPM Flow from the master branch, then you 
 
 .. code-block:: console
 
-    brew install boost openblas suite-sparse python@3.14 cmake
+    brew install cjson boost openblas suite-sparse python@3.14 cmake
 
 In addition, it is recommended to uprade and update your macOS to the latest available versions (the following steps have 
 worked for macOS Tahoe 26.2.0 with Apple clang version 17.0.0).

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -204,7 +204,7 @@ Then, you can try to install flow (v2025.10) by simply typing:</p>
 <section id="source-build-in-macos">
 <h3>Source build in macOS<a class="headerlink" href="#source-build-in-macos" title="Link to this heading"></a></h3>
 <p>If you would like to build the latest OPM Flow from the master branch, then you can first install the prerequisites using brew:</p>
-<div class="highlight-console notranslate"><div class="highlight"><pre><span></span><span class="go">brew install boost openblas suite-sparse python@3.14 cmake</span>
+<div class="highlight-console notranslate"><div class="highlight"><pre><span></span><span class="go">brew install cjson boost openblas suite-sparse python@3.14 cmake</span>
 </pre></div>
 </div>
 <p>In addition, it is recommended to uprade and update your macOS to the latest available versions (the following steps have

--- a/docs/text/installation.rst
+++ b/docs/text/installation.rst
@@ -134,7 +134,7 @@ If you would like to build the latest OPM Flow from the master branch, then you 
 
 .. code-block:: console
 
-    brew install boost openblas suite-sparse python@3.14 cmake
+    brew install cjson boost openblas suite-sparse python@3.14 cmake
 
 In addition, it is recommended to uprade and update your macOS to the latest available versions (the following steps have 
 worked for macOS Tahoe 26.2.0 with Apple clang version 17.0.0).


### PR DESCRIPTION
## Description
Today a PR in [opm-common](https://github.com/OPM/opm-common) has made `cjson` as prerequisite to build OPM Flow.
